### PR TITLE
FIX: attempt to index a nil value (local 'type')

### DIFF
--- a/changes.lua
+++ b/changes.lua
@@ -26,15 +26,17 @@ function changes.parse(diff)
       additions = additions + astart
     elseif dstart > 0 or astart > 0 then
       local type = line:match("^([%+%-%s])")
-      if dstart > 0 and (type == "-" or type:match("%s")) then
-        if type == "-" then deletes[dstart] = "deletion" end
-        dstart = dstart + 1
-        if dstart >= deletions then dstart = 0 end
-      end
-      if astart > 0 and (type == "+" or type:match("%s")) then
-        if type == "+" then inserts[astart] = "addition" end
-        astart = astart + 1
-        if astart >= additions then astart = 0 end
+      if type then
+        if dstart > 0 and (type == "-" or type:match("%s")) then
+          if type == "-" then deletes[dstart] = "deletion" end
+          dstart = dstart + 1
+          if dstart >= deletions then dstart = 0 end
+        end
+        if astart > 0 and (type == "+" or type:match("%s")) then
+          if type == "+" then inserts[astart] = "addition" end
+          astart = astart + 1
+          if astart >= additions then astart = 0 end
+        end
       end
     end
   end

--- a/changes.lua
+++ b/changes.lua
@@ -27,12 +27,13 @@ function changes.parse(diff)
     elseif dstart > 0 or astart > 0 then
       local type = line:match("^([%+%-%s])")
       if type then
-        if dstart > 0 and (type == "-" or type:match("%s")) then
+        local is_space = type:match("%s")
+        if dstart > 0 and (type == "-" or is_space) then
           if type == "-" then deletes[dstart] = "deletion" end
           dstart = dstart + 1
           if dstart >= deletions then dstart = 0 end
         end
-        if astart > 0 and (type == "+" or type:match("%s")) then
+        if astart > 0 and (type == "+" or is_space) then
           if type == "+" then inserts[astart] = "addition" end
           astart = astart + 1
           if astart >= additions then astart = 0 end


### PR DESCRIPTION
Check if a diff line starts with the proper match (`+` or `-`) and then increase counter.

Right now if a given diff line starts with a space, scm outputs an error about expecting the `type` table as `` when it's actually `nil`, because a space doesn't match the patter `^([%+%-%s])`.

Solves https://github.com/lite-xl/lite-xl-scm/issues/3